### PR TITLE
feat(system): add version argument to httpClient

### DIFF
--- a/src/system/net.py
+++ b/src/system/net.py
@@ -101,6 +101,7 @@ def httpClient(
     proxy=None,  # type: Optional[String]
     cookie_policy="ACCEPT_ORIGINAL_SERVER",  # type: Optional[String]
     redirect_policy="NORMAL",  # type: Optional[String]
+    version="HTTP_2",  # type: Optional[String]
     customizer=None,  # type: Optional[Callable[..., Any]]
 ):
     # type: (...) -> JythonHttpClient
@@ -139,6 +140,9 @@ def httpClient(
         redirect_policy: A string representing this client's redirect
             policy. Acceptable values are listed below. Defaults to
             "Normal". Optional.
+        version: A string specifying either HTTP_2 or HTTP_1_1 for the
+            HTTP protocol. When omitted, the previous default of HTTP_2
+            is implied. Optional.
         customizer: A reference to a function. This function will be
             called with one argument (an instance of
             HttpClient.Builder). The function should operate on that
@@ -158,6 +162,7 @@ def httpClient(
         proxy,
         cookie_policy,
         redirect_policy,
+        version,
         customizer,
     )
     return JythonHttpClient()


### PR DESCRIPTION
allow specifying either HTTP_2 or HTTP_1_1 for the HTTP protocol

# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [commit message format](https://github.com/ignition-api/.github/blob/main/CONTRIBUTING.md#commit-message-format=).

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`system.net.httpClient` does not offer the ability to specify the HTTP protocol

Issue Number: N/A

## What is the new behavior?
This change will allow specifying either HTTP_2 or HTTP_1_1 for the HTTP protocol.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
