### PR TITLE
refactor(org): add TYPE field to PyObject class

### DIFF
--- a/src/org/python/core/__init__.py
+++ b/src/org/python/core/__init__.py
@@ -1100,7 +1100,6 @@ class PyTraceback(PyObject):
 
 
 class PyType(PyObject):
-
     @staticmethod
     def addBuilder(c, builder):
         # type: (Class, TypeBuilder) -> None

--- a/src/org/python/core/__init__.py
+++ b/src/org/python/core/__init__.py
@@ -17,6 +17,8 @@ class PyObject(Object):
     an instance of the class PyObject or one of its subclasses.
     """
 
+    TYPE = None  # type: PyType
+
     def __init__(self, objtype=None):
         # type: (Optional[PyType]) -> None
         print(objtype)
@@ -828,7 +830,6 @@ class PyBuiltinMethod(PyBuiltinCallable):
 
 class PyCell(PyObject):
     ob_ref = None  # type: PyObject
-    TYPE = None  # type: PyType
 
     def __init__(self):
         super(PyCell, self).__init__(self.TYPE)
@@ -955,7 +956,6 @@ class PyFrame(PyObject):
     f_nfreevars = None  # type: int
     f_savedlocals = None  # type: List[Object]
     tracefunc = None  # type: TraceFunction
-    TYPE = None  # type: PyType
 
     def __init__(self, *args):
         super(PyFrame, self).__init__(self.TYPE)
@@ -1080,7 +1080,6 @@ class PyTraceback(PyObject):
     tb_frame = None  # type: PyFrame
     tb_lineno = None  # type: int
     tb_next = None  # type: PyObject
-    TYPE = None  # type: PyType
 
     def __init__(self, next, frame):
         # type: (PyTraceback, PyFrame) -> None
@@ -1101,7 +1100,6 @@ class PyTraceback(PyObject):
 
 
 class PyType(PyObject):
-    TYPE = None  # type: PyType
 
     @staticmethod
     def addBuilder(c, builder):


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [commit message format](https://github.com/ignition-api/.github/blob/main/CONTRIBUTING.md#commit-message-format).

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`TYPE` field is present in classes inheriting from `PyObject`

Issue Number: N/A

## What is the new behavior?
<!-- Please describe the new behavior. -->
`TYPE` belongs to `PyObject`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
