### PR TITLE
fix(java): rollback change on classproperty

### DIFF
--- a/src/java/util/__init__.py
+++ b/src/java/util/__init__.py
@@ -8,7 +8,7 @@ from __future__ import print_function
 
 __all__ = ["Date", "EventObject", "Locale"]
 
-from typing import Optional
+from typing import Any, Optional
 
 from java.lang import Object
 
@@ -78,20 +78,9 @@ class EventObject(Object):
         return self.source
 
 
-class classproperty(object):  # pylint: disable=invalid-name
-    """Decorator that converts a method with a single cls argument into
-    a property that can be accessed directly from the class.
-    """
-
-    def __init__(self, method=None):
-        self.fget = method
-
-    def __get__(self, instance, cls=None):
-        return self.fget(cls)
-
-    def getter(self, method):
-        self.fget = method
-        return self
+class classproperty(property):  # pylint: disable=invalid-name
+    def __get__(self, cls, owner):
+        return classmethod(self.fget).__get__(None, owner)()
 
 
 class Locale(Object):

--- a/src/java/util/__init__.py
+++ b/src/java/util/__init__.py
@@ -8,7 +8,7 @@ from __future__ import print_function
 
 __all__ = ["Date", "EventObject", "Locale"]
 
-from typing import Any, Optional
+from typing import Optional
 
 from java.lang import Object
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [commit message format](https://github.com/ignition-api/.github/blob/main/CONTRIBUTING.md#commit-message-format).

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When creating stubs with `mypy`'s `stubgen` it imports `Incomplete` from `_typeshed` as it cannot infer `classproperty`'s `fget` field.

Issue Number: N/A

## What is the new behavior?
<!-- Please describe the new behavior. -->
Rolling back to the previous decorator fixes the issue described above.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
