### PR TITLE
fix(ia): change the return type of dataset columns

### DIFF
--- a/src/com/inductiveautomation/ignition/common/__init__.py
+++ b/src/com/inductiveautomation/ignition/common/__init__.py
@@ -36,11 +36,11 @@ class Dataset(object):
         raise NotImplementedError
 
     def getColumnName(self, col):
-        # type: (int) -> str
+        # type: (int) -> String
         raise NotImplementedError
 
     def getColumnNames(self):
-        # type: () -> List[str]
+        # type: () -> List[String]
         raise NotImplementedError
 
     def getColumnType(self, col):
@@ -107,11 +107,11 @@ class AbstractDataset(Dataset):
         pass
 
     def getColumnName(self, col):
-        # type: (int) -> str
+        # type: (int) -> String
         pass
 
     def getColumnNames(self):
-        # type: () -> List[str]
+        # type: () -> List[String]
         pass
 
     def getColumnType(self, col):

--- a/src/com/inductiveautomation/ignition/common/script/builtin/__init__.py
+++ b/src/com/inductiveautomation/ignition/common/script/builtin/__init__.py
@@ -219,11 +219,11 @@ class DatasetUtilities(Object):
             pass
 
         def getColumnName(self, col):
-            # type: (int) -> str
+            # type: (int) -> String
             pass
 
         def getColumnNames(self):
-            # type: () -> List[str]
+            # type: () -> List[String]
             pass
 
         def getColumnType(self, col):


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [commit message format](https://github.com/ignition-api/.github/blob/main/CONTRIBUTING.md#commit-message-format).

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Dataset column names are currently set to type `str`

Issue Number: N/A

## What is the new behavior?
<!-- Please describe the new behavior. -->
Column names will be of type `Union[str, unicode]`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
