### PR TITLE
refactor: return Iterator from iter methods

### DIFF
--- a/src/com/inductiveautomation/ignition/common/alarming/__init__.py
+++ b/src/com/inductiveautomation/ignition/common/alarming/__init__.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 __all__ = ["AlarmEvent", "EventData", "PyAlarmEvent", "PyAlarmEventImpl"]
 
-from typing import Any, Iterable
+from typing import Any, Iterator
 
 from com.inductiveautomation.ignition.common.config import BasicPropertySet
 from org.python.core import PyObject
@@ -10,7 +10,7 @@ from org.python.core import PyObject
 
 class AlarmEvent(object):
     def __iter__(self):
-        # type: () -> Iterable[Any]
+        # type: () -> Iterator[Any]
         raise NotImplementedError
 
     def acknowledge(self, ackData):
@@ -84,7 +84,7 @@ class EventData(BasicPropertySet):
 
 class PyAlarmEvent(AlarmEvent):
     def __iter__(self):
-        # type: () -> Iterable[Any]
+        # type: () -> Iterator[Any]
         pass
 
     def acknowledge(self, ackData):

--- a/src/org/python/core/__init__.py
+++ b/src/org/python/core/__init__.py
@@ -24,7 +24,7 @@ __all__ = [
 ]
 
 from enum import Enum
-from typing import Any, Iterable, List, Optional, Tuple, Union
+from typing import Any, Iterable, Iterator, List, Optional, Tuple, Union
 
 from java.io import PrintWriter
 from java.lang import Class, Object, RuntimeException, String, StringBuilder, Throwable
@@ -215,7 +215,7 @@ class PyObject(Object):
         pass
 
     def __iter__(self):
-        # type: () -> Iterable[PyObject]
+        # type: () -> Iterator[PyObject]
         pass
 
     def __iternext__(self):


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [commit message format](https://github.com/ignition-api/.github/blob/main/CONTRIBUTING.md#commit-message-format).

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`__iter__` methods return `typing.Iterable`

Issue Number: N/A

## What is the new behavior?
<!-- Please describe the new behavior. -->
`__iter__` methods return `typing.Iterator`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

flake8-pyi(Y045) "__iter__" methods should return an Iterator, not an Iterable