### PR TITLE
feat(ia): add getNodeId() to OPCBrowseElement

### DIFF
--- a/src/com/inductiveautomation/ignition/common/opc/__init__.py
+++ b/src/com/inductiveautomation/ignition/common/opc/__init__.py
@@ -29,6 +29,10 @@ class OPCBrowseElement(object):
         # type: () -> BrowseElementType
         raise NotImplementedError
 
+    def getNodeId(self):
+        # type: () -> String
+        raise NotImplementedError
+
     def getServerNodeId(self):
         # type: () -> ServerNodeId
         raise NotImplementedError
@@ -63,6 +67,10 @@ class BasicOPCBrowseElement(Object, OPCBrowseElement):
 
     def getElementType(self):
         # type: () -> BrowseElementType
+        pass
+
+    def getNodeId(self):
+        # type: () -> String
         pass
 
     def getServerNodeId(self):
@@ -130,6 +138,10 @@ class ServerBrowseElement(Object, OPCBrowseElement):
     def getElementType(self):
         # type: () -> BrowseElementType
         return BrowseElementType.SERVER
+
+    def getNodeId(self):
+        # type: () -> String
+        return self.getServerNodeId().getNodeId()
 
     def getServerNodeId(self):
         # type: () -> ServerNodeId

--- a/src/system/opc.py
+++ b/src/system/opc.py
@@ -60,7 +60,7 @@ def browseServer(
 ):
     # type: (...) -> List[Union[BasicOPCBrowseElement, PyOPCTag]]
     """When called from a Vision Client, returns a list of
-    OPCBrowseElement objects for the given Server. Otherwise returns a
+    OPCBrowseElement objects for the given Server. Otherwise, returns a
     list of PyOPCTag.
 
     Args:


### PR DESCRIPTION
new in 8.1.20

Closes: #68

# PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [commit message format](https://github.com/ignition-api/.github/blob/main/CONTRIBUTING.md#commit-message-format).

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Ignition 8.1.19 did not have `getNodeId()` for `OPCBrowseElement`.

Issue Number: #68

## What is the new behavior?
<!-- Please describe the new behavior. -->
`getNodeId()` is now available on `OPCBrowseElement` and all classes implementing that interface.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
