### PR TITLE
fix(system): accept String arguments for popup position

### DIFF
--- a/src/system/perspective/__init__.py
+++ b/src/system/perspective/__init__.py
@@ -36,7 +36,7 @@ __all__ = [
 
 import __builtin__ as builtins
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from com.inductiveautomation.ignition.common.gson import JsonObject
 from com.inductiveautomation.ignition.common.script.adapters import PyJsonObjectAdapter
@@ -500,7 +500,7 @@ def openPopup(
     view,  # type: String
     params=None,  # type: Optional[Dict[String, Any]]
     title="",  # type: String
-    position=None,  # type: Optional[Dict[String, int]]
+    position=None,  # type: Optional[Dict[String, Union[int, String]]]
     showCloseIcon=True,  # type: bool
     draggable=True,  # type: bool
     resizable=False,  # type: bool
@@ -694,7 +694,7 @@ def togglePopup(
     view,  # type: String
     params,  # type: Optional[Dict[String, Any]]
     title="",  # type: String
-    position=None,  # type: Optional[Dict[String, int]]
+    position=None,  # type: Optional[Dict[String, Union[int, String]]]
     showCloseIcon=True,  # type: bool
     draggable=True,  # type: bool
     resizable=False,  # type: bool


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [commit message format](https://github.com/ignition-api/.github/blob/main/CONTRIBUTING.md#commit-message-format).

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`position` argument only accepts `Dict[String, int]`.

E.g. "40%"

Issue Number: N/A

## What is the new behavior?
<!-- Please describe the new behavior. -->
`position` argument only accepts `Dict[String, Union[int, String]]`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
