### PR TITLE
fix(ia): accept unicode arg in SProcCall functions

### DIFF
--- a/src/com/inductiveautomation/ignition/common/script/builtin/__init__.py
+++ b/src/com/inductiveautomation/ignition/common/script/builtin/__init__.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 __all__ = ["AbstractOPCUtilities", "DatasetUtilities", "SProcCall", "SystemUtilities"]
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from com.inductiveautomation.ignition.common import BasicDataset, Dataset
 from com.inductiveautomation.ignition.common.model.values import QualityCode
@@ -10,8 +10,10 @@ from com.inductiveautomation.ignition.common.opc import BrowseElementType
 from com.inductiveautomation.ignition.common.script.abc import AbstractJythonSequence
 from com.inductiveautomation.ignition.common.script.message import Request
 from java.lang import Class, Object, String
+from java.lang import Exception as JavaException
 from java.util import Locale
-from org.python.core import PyObject
+from org.python.core import PyFunction, PyObject
+from org.slf4j import Logger
 
 
 class AbstractOPCUtilities(Object):
@@ -60,7 +62,7 @@ class AbstractOPCUtilities(Object):
             super(AbstractOPCUtilities.PyOPCTag, self).__init__()
 
         def __findattr_ex__(self, name):
-            # type: (str) -> PyObject
+            # type: (String) -> PyObject
             pass
 
         def getDisplayName(self):
@@ -164,7 +166,7 @@ class DatasetUtilities(Object):
     @staticmethod
     def sort(
         ds,  # type: BasicDataset
-        keyColumn,  # type: Union[int, str]
+        keyColumn,  # type: Union[int, String]
         ascending=None,  # type: Optional[bool]
         naturalOrdering=None,  # type: Optional[bool]
     ):
@@ -344,16 +346,16 @@ class SProcCall(Object):
     updateCount = None  # type: int
 
     def getDataSource(self):
-        # type: () -> str
+        # type: () -> String
         pass
 
     def getOutParamValue(self, param):
-        # type: (Union[int, str]) -> Any
+        # type: (Union[int, String]) -> Any
         print(self, param)
         return 0
 
     def getProcedureName(self):
-        # type: () -> str
+        # type: () -> String
         pass
 
     def getResultSet(self):
@@ -367,7 +369,7 @@ class SProcCall(Object):
         return 0
 
     def getTxId(self):
-        # type: () -> str
+        # type: () -> String
         return "transaction_id"
 
     def getUpdateCount(self):
@@ -381,11 +383,11 @@ class SProcCall(Object):
         return False
 
     def registerInParam(self, param, typeCode, value):
-        # type: (Union[int, str], int, Any) -> None
+        # type: (Union[int, String], int, Any) -> None
         print(self, param, typeCode, value)
 
     def registerOutParam(self, param, typeCode):
-        # type: (Union[int, str], int) -> None
+        # type: (Union[int, String], int) -> None
         print(self, param, typeCode)
 
     def registerReturnParam(self, typeCode):
@@ -415,15 +417,19 @@ class SProcCall(Object):
             pass
 
         def isInParam(self):
+            # type: () -> bool
             pass
 
         def isOutParam(self):
+            # type: () -> bool
             pass
 
         def setParamType(self, paramType):
+            # type: (int) -> None
             pass
 
         def setValue(self, value):
+            # type: (Object) -> None
             pass
 
     class SProcArgKey(Object):
@@ -431,22 +437,27 @@ class SProcCall(Object):
         name = None  # type: String
 
         def getParamIndex(self):
+            # type: () -> int
             pass
 
         def getParamName(self):
+            # type: () -> String
             pass
 
         def isNamedParam(self):
+            # type: () -> bool
             pass
 
 
 class SystemUtilities(Object):
     @staticmethod
     def logger(loggerName):
+        # type: (String) -> Logger
         pass
 
     @staticmethod
     def parseTranslateArguments(*args, **kwargs):
+        # type: (PyObject, String) -> Tuple[String, String, bool]
         pass
 
     class RequestImpl(Object, Request):
@@ -456,32 +467,38 @@ class SystemUtilities(Object):
             # type: (int) -> None
             self.timeout = timeout
 
-        def checkTimeout(self):
+        def cancel(self):
+            # type: () -> None
             pass
 
-        def dispatchFunc(self):
+        def checkTimeout(self):
+            # type: () -> None
             pass
 
         def finishExceptionally(self, e):
+            # type: (JavaException) -> None
             pass
 
         def finishSuccessfully(self, value):
-            pass
-
-        def getLongId(self):
-            pass
-
-        def cancel(self):
+            # type: (Object) -> None
             pass
 
         def get(self):
+            # type: () -> Object
             pass
 
         def getError(self):
+            # type: () -> JavaException
+            pass
+
+        def getLongId(self):
+            # type: () -> long
             pass
 
         def onError(self, func):
+            # type: (PyFunction) -> None
             pass
 
         def onSuccess(self, func):
+            # type: (PyFunction) -> None
             pass

--- a/src/com/inductiveautomation/ignition/common/script/builtin/__init__.py
+++ b/src/com/inductiveautomation/ignition/common/script/builtin/__init__.py
@@ -9,8 +9,9 @@ from com.inductiveautomation.ignition.common.model.values import QualityCode
 from com.inductiveautomation.ignition.common.opc import BrowseElementType
 from com.inductiveautomation.ignition.common.script.abc import AbstractJythonSequence
 from com.inductiveautomation.ignition.common.script.message import Request
-from java.lang import Class, Object, String
+from java.lang import Class
 from java.lang import Exception as JavaException
+from java.lang import Object, String
 from java.util import Locale
 from org.python.core import PyFunction, PyObject
 from org.slf4j import Logger

--- a/src/com/inductiveautomation/ignition/common/script/message/__init__.py
+++ b/src/com/inductiveautomation/ignition/common/script/message/__init__.py
@@ -1,32 +1,45 @@
 __all__ = ["Request", "RequestWatcher"]
 
+from java.lang import Object
+from java.lang import Exception as JavaException
+from org.python.core import PyFunction
+
 
 class RequestWatcher(object):
     def block(self):
+        # type: () -> bool
         raise NotImplementedError
 
-    def compose(self, requestWatchers):
+    def compose(self, *args):
+        # type: (RequestWatcher) -> RequestWatcher
         raise NotImplementedError
 
 
 class Request(RequestWatcher):
     def block(self):
+        # type: () -> bool
         pass
 
     def cancel(self):
+            # type: () -> None
         raise NotImplementedError
 
-    def compose(self, requestWatchers):
+    def compose(self, *args):
+        # type: (RequestWatcher) -> RequestWatcher
         pass
 
     def get(self):
+            # type: () -> Object
         raise NotImplementedError
 
     def getError(self):
+            # type: () -> JavaException
         raise NotImplementedError
 
     def onError(self, func):
+            # type: (PyFunction) -> None
         raise NotImplementedError
 
     def onSuccess(self, func):
+            # type: (PyFunction) -> None
         raise NotImplementedError

--- a/src/com/inductiveautomation/ignition/common/script/message/__init__.py
+++ b/src/com/inductiveautomation/ignition/common/script/message/__init__.py
@@ -1,7 +1,7 @@
 __all__ = ["Request", "RequestWatcher"]
 
-from java.lang import Object
 from java.lang import Exception as JavaException
+from java.lang import Object
 from org.python.core import PyFunction
 
 
@@ -21,7 +21,7 @@ class Request(RequestWatcher):
         pass
 
     def cancel(self):
-            # type: () -> None
+        # type: () -> None
         raise NotImplementedError
 
     def compose(self, *args):
@@ -29,17 +29,17 @@ class Request(RequestWatcher):
         pass
 
     def get(self):
-            # type: () -> Object
+        # type: () -> Object
         raise NotImplementedError
 
     def getError(self):
-            # type: () -> JavaException
+        # type: () -> JavaException
         raise NotImplementedError
 
     def onError(self, func):
-            # type: (PyFunction) -> None
+        # type: (PyFunction) -> None
         raise NotImplementedError
 
     def onSuccess(self, func):
-            # type: (PyFunction) -> None
+        # type: (PyFunction) -> None
         raise NotImplementedError

--- a/src/org/python/core/__init__.py
+++ b/src/org/python/core/__init__.py
@@ -13,6 +13,7 @@ __all__ = [
     "PyDescriptor",
     "PyException",
     "PyFrame",
+    "PyFunction",
     "PyMethodDescr",
     "PyNewWrapper",
     "PyObject",
@@ -1053,6 +1054,12 @@ class PyFrame(PyObject):
     def traverse(self, visit, arg):
         # type: (Visitproc, Object) -> int
         pass
+
+
+class PyFunction(PyObject):
+    def __init__(self, *args):
+        print(args)
+        super(PyFunction, self).__init__()
 
 
 class PyMethodDescr(PyDescriptor):


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [commit message format](https://github.com/ignition-api/.github/blob/main/CONTRIBUTING.md#commit-message-format).

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`SProcCall` `getOut|register[In|Out]Param` has type `Union[int, str]`

Issue Number: #79

## What is the new behavior?
<!-- Please describe the new behavior. -->
`SProcCall` `getOut|register[In|Out]Param` has type `Union[int, str, unicode]`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
