### PR TITLE
ci(github): freeze mypy to version 0.971

### DIFF
--- a/requirements.ci.txt
+++ b/requirements.ci.txt
@@ -1,3 +1,3 @@
-mypy[python2]<0.980
+mypy[python2]==0.971
 pylint
 types-enum34


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [commit message format](https://github.com/ignition-api/.github/blob/main/CONTRIBUTING.md#commit-message-format).

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
We are installing `mypy<0.980`.

Issue Number: N/A

## What is the new behavior?
<!-- Please describe the new behavior. -->
We are freezing our dependency on `mypy` to `v0.971`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Version 0.971 was the last version to support Python 2