### PR TITLE
build(deps): use tox.ini for pydocstyle

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,8 +23,6 @@ repos:
     rev: 6.1.1
     hooks:
       - id: pydocstyle
-        additional_dependencies:
-          - '.[toml]'
         exclude: ^(src/com/|src/dev/|src/java/|src/javax/|src/org/)
   - repo: local
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,3 @@ py_version = 27
 
 [tool.mypy]
 python_version = 2.7
-
-[tool.pydocstyle]
-convention = "google"
-add_ignore = ["D205", "D415"]
-match_dir = "system"

--- a/tox.ini
+++ b/tox.ini
@@ -32,4 +32,9 @@ commands =
 [gh]
 python =
     2.7 = install
-    3.10 = lint,typecheck
+    3.10 = lint, typecheck
+
+[pydocstyle]
+convention = google
+add_ignore = D205, D415
+match_dir = [^\(com,dev,org,java)].*


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [commit message format](https://github.com/ignition-api/.github/blob/main/CONTRIBUTING.md#commit-message-format).

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
We are configuring `pydocstyle` in `pyproject.toml`, which makes us install `pydocstyle[toml]`.

As pointed out by other users, the `toml` library is no longer maintained, and starting with Python 3.11 `tomlib` will become a direct substitution.

Issue Number: N/A

## What is the new behavior?
<!-- Please describe the new behavior. -->
`pre-commit` will no longer install the `[toml]` extras for `pydocstyle` as it will get its settings from `tox.ini` instead of `pyproject.toml`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
