### PR TITLE
build(deps): use tox.ini for flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,0 @@
-[flake8]
-ignore = E741, F401, F821
-max-complexity = 10
-max-doc-length = 72
-max-line-length = 88

--- a/src/com/inductiveautomation/ignition/common/user/schedule/__init__.py
+++ b/src/com/inductiveautomation/ignition/common/user/schedule/__init__.py
@@ -7,7 +7,7 @@ __all__ = [
 ]
 
 from com.palantir.ptoss.cinch.core import DefaultBindableModel
-from java.lang import Object, String
+from java.lang import String
 from java.util import Date
 
 

--- a/src/javax/swing/event/__init__.py
+++ b/src/javax/swing/event/__init__.py
@@ -1,7 +1,4 @@
-from typing import Any
-
 from java.awt import AWTEvent, Component, Container
-from java.lang import Object
 
 
 class AncestorEvent(AWTEvent):

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,12 @@ deps =
 commands =
     mypy --install-types --non-interactive src
 
+[flake8]
+ignore = E741, F821
+max-complexity = 10
+max-doc-length = 72
+max-line-length = 88
+
 [gh]
 python =
     2.7 = install


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [commit message format](https://github.com/ignition-api/.github/blob/main/CONTRIBUTING.md#commit-message-format).

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
We use `.flake8` for `flake8`'s settings.

Issue Number: N/A

## What is the new behavior?
<!-- Please describe the new behavior. -->
With the introduction of `tox.ini` we can safely move `flake8`'s configuration from `.flake8` to `tox.ini`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
