### PR TITLE
build(deps): use tox.ini for isort

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,5 @@ requires = [
 [tool.commitizen]
 name = "cz_conventional_commits"
 
-[tool.isort]
-profile = "black"
-py_version = 27
-
 [tool.mypy]
 python_version = 2.7

--- a/src/com/inductiveautomation/ignition/common/gson/stream/__init__.py
+++ b/src/com/inductiveautomation/ignition/common/gson/stream/__init__.py
@@ -1,7 +1,8 @@
 from __future__ import print_function
 
-from enum import Enum
 from typing import Any
+
+from enum import Enum
 
 from java.io import Closeable, Flushable, Reader, Writer
 from java.lang import Object, String

--- a/src/com/inductiveautomation/ignition/common/model/__init__.py
+++ b/src/com/inductiveautomation/ignition/common/model/__init__.py
@@ -1,7 +1,6 @@
 __all__ = ["ApplicationScope", "Version"]
 
 import re
-
 from typing import Any, Optional, Tuple, Union
 
 from java.io import InputStream

--- a/src/com/inductiveautomation/ignition/common/model/values/__init__.py
+++ b/src/com/inductiveautomation/ignition/common/model/values/__init__.py
@@ -1,7 +1,8 @@
 __all__ = ["BasicQualifiedValue", "QualifiedValue", "Quality", "QualityCode"]
 
-from enum import Enum
 from typing import Any, Union
+
+from enum import Enum
 
 from dev.thecesrom.utils.decorators import classproperty
 from java.lang import Object, String

--- a/src/java/lang/__init__.py
+++ b/src/java/lang/__init__.py
@@ -27,7 +27,6 @@ __all__ = [
 
 import __builtin__ as builtins
 import time
-
 from typing import Any, List, Optional, TypeVar, Union
 
 String = Union[str, unicode]

--- a/src/org/python/core/__init__.py
+++ b/src/org/python/core/__init__.py
@@ -24,8 +24,9 @@ __all__ = [
     "Visitproc",
 ]
 
-from enum import Enum
 from typing import Any, Iterable, Iterator, List, Optional, Tuple, Union
+
+from enum import Enum
 
 from java.io import PrintWriter
 from java.lang import Class, Object, RuntimeException, String, StringBuilder, Throwable

--- a/src/system/dataset.py
+++ b/src/system/dataset.py
@@ -32,7 +32,6 @@ __all__ = [
 ]
 
 import os.path
-
 from typing import Any, Dict, List, Optional, Type, Union
 
 from com.inductiveautomation.ignition.common import BasicDataset, Dataset

--- a/src/system/date.py
+++ b/src/system/date.py
@@ -53,7 +53,6 @@ __all__ = [
 
 from datetime import datetime
 from time import localtime, mktime
-
 from typing import Optional
 
 from java.lang import String

--- a/src/system/file.py
+++ b/src/system/file.py
@@ -19,7 +19,6 @@ __all__ = [
 import io
 import os.path
 import tempfile
-
 from typing import Any, List, Optional
 
 from java.lang import String

--- a/src/system/math.py
+++ b/src/system/math.py
@@ -28,7 +28,6 @@ __all__ = [
 ]
 
 import __builtin__ as builtins
-
 from typing import List, Union
 
 from org.apache.commons.math3.exception import DimensionMismatchException

--- a/src/system/net.py
+++ b/src/system/net.py
@@ -20,7 +20,6 @@ __all__ = [
 ]
 
 import socket
-
 from typing import Any, Callable, Dict, List, Optional
 
 from com.inductiveautomation.ignition.common.script.builtin.http import JythonHttpClient

--- a/src/system/perspective/__init__.py
+++ b/src/system/perspective/__init__.py
@@ -35,7 +35,6 @@ __all__ = [
 ]
 
 import __builtin__ as builtins
-
 from typing import Any, Dict, List, Optional, Union
 
 from com.inductiveautomation.ignition.common.gson import JsonObject

--- a/src/system/security.py
+++ b/src/system/security.py
@@ -21,7 +21,6 @@ __all__ = [
 ]
 
 import getpass
-
 from typing import Optional, Tuple
 
 from java.lang import String

--- a/src/system/util.py
+++ b/src/system/util.py
@@ -62,7 +62,6 @@ import getpass
 import json
 import os
 import platform
-
 from typing import Any, Callable, Dict, Iterable, List, Optional, Union
 
 import system.__version__ as version

--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,11 @@ python =
     2.7 = install
     3.10 = lint, typecheck
 
+[isort]
+extra_standard_library = typing
+profile = black
+py_version = 27
+
 [pydocstyle]
 convention = google
 add_ignore = D205, D415


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [commit message format](https://github.com/ignition-api/.github/blob/main/CONTRIBUTING.md#commit-message-format).

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
We use `pyproject.toml` for configuring `isort`.

Issue Number: N/A

## What is the new behavior?
<!-- Please describe the new behavior. -->
We will use `tox.ini` and treat `typing` as part of the standard library, just like in `ignition-api-stubs`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
