### PR TITLE
revert(ci): use tox-gh for running tox in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install tox
+        python -m pip install --requirement requirements.ci.txt
     - name: Setup test suite
       run: |
         tox --notest

--- a/requirements.ci.txt
+++ b/requirements.ci.txt
@@ -1,0 +1,2 @@
+tox; python_version=='2.7'
+tox-gh; python_version>='3.10'

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,11 @@ max-complexity = 10
 max-doc-length = 72
 max-line-length = 88
 
+[gh]
+python =
+    2.7 = install
+    3.10 = lint, typecheck
+
 [isort]
 extra_standard_library = typing
 profile = black


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [commit message format](https://github.com/ignition-api/.github/blob/main/CONTRIBUTING.md#commit-message-format).

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`tox`'s `install` env is being executed even when we use Python 3.10 on our CI workflow.

Issue Number: N/A

## What is the new behavior?
<!-- Please describe the new behavior. -->
`install` env will only be executed when using Python 2.7.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

prevent running py27 env when using Python 3.10 in CI

Refs: 8f6c733d, 9983e90
