### PR TITLE
feat(system): allow java.util.Locale objects to be passed in as param…

### DIFF
--- a/src/system/util.py
+++ b/src/system/util.py
@@ -75,7 +75,7 @@ from com.inductiveautomation.ignition.common.script.builtin import (
 from com.inductiveautomation.ignition.common.util import LoggerEx
 from java.awt import Toolkit
 from java.lang import String, Thread
-from java.util import Date
+from java.util import Date, Locale
 
 APPLET_FLAG = 16
 CLIENT_FLAG = 4
@@ -947,7 +947,7 @@ def setConnectionMode(mode):
 
 
 def setLocale(locale):
-    # type: (String) -> None
+    # type: (Union[String, Locale]) -> None
     """Sets the user's current Locale.
 
     Any valid Java locale code (case-insensitive) can be used as a
@@ -955,7 +955,8 @@ def setLocale(locale):
     Translation Manager.
 
     Args:
-        locale: A locale code, such as 'en_US' for US English.
+        locale: A locale code, such as 'en_US' for US English, or a
+            java.util.Locale object.
 
     Raises:
         IllegalArgumentException: If passed an invalid local code.


### PR DESCRIPTION
…eters

# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [commit message format](https://github.com/ignition-api/.github/blob/main/CONTRIBUTING.md#commit-message-format).

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`system.util.sretLocale` only accepts String type as parameter.

Issue Number: #124

## What is the new behavior?
<!-- Please describe the new behavior. -->
`system.util.sretLocale` allows `java.util.Locale` objects to be passed in as parameter.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
