### PR TITLE
fix: create Number type alias

### DIFF
--- a/src/com/inductiveautomation/ignition/common/gson/__init__.py
+++ b/src/com/inductiveautomation/ignition/common/gson/__init__.py
@@ -22,6 +22,7 @@ from com.inductiveautomation.ignition.common.gson.stream import JsonReader, Json
 from java.io import Reader, Writer
 from java.lang import Class, Enum, Object, String
 
+Number = Union[float, int, long]
 T = TypeVar("T")
 
 
@@ -300,7 +301,7 @@ class JsonElement(object):
         raise NotImplementedError
 
     def getAsNumber(self):
-        # type: () -> Union[float, int, long]
+        # type: () -> Number
         raise NotImplementedError
 
     def getAsShort(self):
@@ -382,7 +383,7 @@ class JsonArray(JsonElement):
         pass
 
     def getAsNumber(self):
-        # type: () -> Union[float, int, long]
+        # type: () -> Number
         pass
 
     def getAsShort(self):
@@ -444,7 +445,7 @@ class JsonNull(JsonElement):
         pass
 
     def getAsNumber(self):
-        # type: () -> Union[float, int, long]
+        # type: () -> Number
         pass
 
     def getAsShort(self):
@@ -510,7 +511,7 @@ class JsonObject(JsonElement):
         pass
 
     def getAsNumber(self):
-        # type: () -> Union[float, int, long]
+        # type: () -> Number
         pass
 
     def getAsShort(self):
@@ -576,7 +577,7 @@ class JsonPrimitive(JsonElement):
         pass
 
     def getAsNumber(self):
-        # type: () -> Union[float, int, long]
+        # type: () -> Number
         pass
 
     def getAsShort(self):

--- a/src/system/dnp3.py
+++ b/src/system/dnp3.py
@@ -26,9 +26,11 @@ __all__ = [
 
 from typing import List, Optional, Union
 
-# Constants
 from java.lang import String
 
+Number = Union[float, int]
+
+# Constants
 NUL = 0
 PULSE_ON = 1
 PULSE_OFF = 2
@@ -41,7 +43,7 @@ TRIP = 2
 def directOperateAnalog(
     deviceName,  # type: String
     index,  # type: int
-    value,  # type: Union[float, int]
+    value,  # type: Number
     variation=None,  # type: Optional[int]
 ):
     # type: (...) -> int
@@ -159,7 +161,7 @@ def freezeCountersAtTime(deviceName, absoluteTime, intervalTime, indexes):
 def selectOperateAnalog(
     deviceName,  # type: String
     index,  # type: int
-    value,  # type: Union[float, int]
+    value,  # type: Number
     variation=None,  # type: Optional[int]
 ):
     # type: (...) -> int

--- a/src/system/gui.py
+++ b/src/system/gui.py
@@ -68,6 +68,8 @@ from javax.swing import (
     JTextField,
 )
 
+Number = Union[float, int]
+
 # Constants
 ACCL_NONE = 0
 ACCL_CONSTANT = 1
@@ -580,11 +582,11 @@ def setTouchscreenModeEnabled(enabled):
 
 
 def showNumericKeypad(
-    initialValue,  # type: Union[float, int]
+    initialValue,  # type: Number
     fontSize=None,  # type: Optional[int]
     usePasswordMode=False,  # type: bool
 ):
-    # type: (...) -> Union[float, int]
+    # type: (...) -> Number
     """Displays a modal on-screen numeric keypad, allowing for arbitrary
     numeric entry using the mouse, or a finger on a touchscreen monitor.
 

--- a/src/system/math.py
+++ b/src/system/math.py
@@ -32,9 +32,11 @@ from typing import List, Union
 
 from org.apache.commons.math3.exception import DimensionMismatchException
 
+Number = Union[float, int]
+
 
 def geometricMean(values):
-    # type: (List[Union[float, int]]) -> float
+    # type: (List[Number]) -> float
     """Calculates the geometric mean.
 
     Geometric Mean is a type of average which indicates a typical value
@@ -58,7 +60,7 @@ def geometricMean(values):
 
 
 def kurtosis(values):
-    # type: (List[Union[float, int]]) -> float
+    # type: (List[Number]) -> float
     """Calculates the kurtosis of a sequence of values.
 
     Kurtosis measures if data is peaked or flat relative to normal
@@ -87,7 +89,7 @@ def kurtosis(values):
 
 
 def max(values):
-    # type: (List[Union[float, int]]) -> float
+    # type: (List[Number]) -> float
     """Given a sequence of values, returns the greatest value in the
     sequence, also known as the "max" value.
 
@@ -107,7 +109,7 @@ def max(values):
 
 
 def mean(values):
-    # type: (List[Union[float, int]]) -> float
+    # type: (List[Number]) -> float
     """Given a sequence of values, calculates the arithmetic mean
     (average).
 
@@ -127,7 +129,7 @@ def mean(values):
 
 
 def meanDifference(values1, values2):
-    # type: (List[Union[float, int]], List[Union[float, int]]) -> float
+    # type: (List[Number], List[Number]) -> float
     """Given two sequences of values, calculates the mean of the signed
     difference between both sequences.
 
@@ -158,7 +160,7 @@ def meanDifference(values1, values2):
 
 
 def median(values):
-    # type: (List[Union[float, int]]) -> float
+    # type: (List[Number]) -> float
     """Takes a sequence of values, and returns the median.
 
     The Median represents the middle value in a set of data.
@@ -179,7 +181,7 @@ def median(values):
 
 
 def min(values):
-    # type: (List[Union[float, int]]) -> float
+    # type: (List[Number]) -> float
     """Given a Sequence of numerical values, returns the minimum value,
     also known as the "min" value.
 
@@ -199,7 +201,7 @@ def min(values):
 
 
 def mode(values):
-    # type: (List[Union[float, int]]) -> List[float]
+    # type: (List[Number]) -> List[float]
     """Given a sequence of values, returns the 'mode', or most frequent
     values.
 
@@ -220,7 +222,7 @@ def mode(values):
 
 
 def normalize(values):
-    # type: (List[Union[float, int]]) -> List[float]
+    # type: (List[Number]) -> List[float]
     """Given a sequence of values, normalizes the values.
 
     Normalizing data refers to adjusting values measured on different
@@ -247,7 +249,7 @@ def normalize(values):
 
 
 def percentile(values, percentile):
-    # type: (List[Union[float, int]], float) -> float
+    # type: (List[Number], float) -> float
     """Given a sequence of numerical values, estimates the percentile of
     input.
 
@@ -276,7 +278,7 @@ def percentile(values, percentile):
 
 
 def populationVariance(values):
-    # type: (List[Union[float, int]]) -> float
+    # type: (List[Number]) -> float
     """Given a sequence of values, returns the Population Variance.
 
     Population variance calculates how values in a dataset are spread
@@ -298,7 +300,7 @@ def populationVariance(values):
 
 
 def product(values):
-    # type: (List[Union[float, int]]) -> float
+    # type: (List[Number]) -> float
     """Given a sequence of values, calculates the product of the
     sequence: the result of multiplying of all values in the sequence
     together.
@@ -320,7 +322,7 @@ def product(values):
 
 
 def skewness(values):
-    # type: (List[Union[float, int]]) -> float
+    # type: (List[Number]) -> float
     """Calculates the skewness given a sequence of values.
 
     Skewness is a measure of the degree of asymmetry of a distribution
@@ -345,7 +347,7 @@ def skewness(values):
 
 
 def standardDeviation(values):
-    # type: (List[Union[float, int]]) -> float
+    # type: (List[Number]) -> float
     """Given a Sequence of numerical values, calculates the standard
     deviation.
 
@@ -369,7 +371,7 @@ def standardDeviation(values):
 
 
 def sum(values):
-    # type: (List[Union[float, int]]) -> float
+    # type: (List[Number]) -> float
     """Given a sequence of values, calculates the sum of all values.
 
     The sum is the number returned by addition.
@@ -390,7 +392,7 @@ def sum(values):
 
 
 def sumDifference(values1, values2):
-    # type: (List[Union[float, int]], List[Union[float, int]]) -> float
+    # type: (List[Number], List[Number]) -> float
     """Given two sequences of values, calculates the sum of the signed
     difference between both sequences.
 
@@ -420,7 +422,7 @@ def sumDifference(values1, values2):
 
 
 def sumLog(values):
-    # type: (List[Union[float, int]]) -> float
+    # type: (List[Number]) -> float
     """Given a sequence of values, calculates the sum of the natural
     logs.
 
@@ -441,7 +443,7 @@ def sumLog(values):
 
 
 def sumSquares(values):
-    # type: (List[Union[float, int]]) -> float
+    # type: (List[Number]) -> float
     """Given a sequence of values, calculates the sum of the squares of
     all values.
 
@@ -464,7 +466,7 @@ def sumSquares(values):
 
 
 def variance(values):
-    # type: (List[Union[float, int]]) -> float
+    # type: (List[Number]) -> float
     """Given a sequence of values, calculates the variance of all
     values.
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [commit message format](https://github.com/ignition-api/.github/blob/main/CONTRIBUTING.md#commit-message-format)
- [x] All applicable pre-commit hooks have passed when running `pre-commit run --all-files`
- [x] All `tox` tests have succeeded

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
We are not using type aliases for `Union[float, int]` types.

Issue Number: #135

## What is the new behavior?
<!-- Please describe the new behavior. -->
We have created aliases for those `Union`s.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
