### PR TITLE
ci(publish): use coatl-dev/action-pypi-upload@v0.2.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,10 @@ on:
       - published
 
 jobs:
-  main:
-    uses: coatl-dev/workflows/.github/workflows/pypi-upload.yml@v4.0.1
-    secrets:
-      password: ${{ secrets.PYPI_API_TOKEN_IGNITION_API_PKG }}
+  pypi-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: python2-pypi-upload
+        uses: coatl-dev/action-pypi-upload@v0.2.0
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN_IGNITION_API_PKG }}


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [commit message format](https://github.com/ignition-api/.github/blob/main/CONTRIBUTING.md#commit-message-format)
- [x] All applicable pre-commit hooks have passed when running `pre-commit run --all-files`
- [x] All `tox` tests have succeeded

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
We are using coatl-dev/workflows/.github/workflows/pypi-upload.yml@v4.0.1

Issue Number: N/A

## What is the new behavior?
<!-- Please describe the new behavior. -->
With GitHub dropping python2.7 from `ubuntu-20.04` we have to rely on the `coatl-dev/action-pypi-upload` action

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
