### PR TITLE
ci: use major version tags for workflows and actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,6 @@ on:
 
 jobs:
   test:
-    uses: coatl-dev/workflows/.github/workflows/tox-docker.yml@v5.1.2
+    uses: coatl-dev/workflows/.github/workflows/tox-docker.yml@v5
     with:
       pre-commit: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,6 @@ jobs:
         uses: actions/checkout@v3
 
       - name: python2-pypi-upload
-        uses: coatl-dev/action-pypi-upload@v1.1.0
+        uses: coatl-dev/action-pypi-upload@v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN_IGNITION_API_PKG }}


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [commit message format](https://github.com/ignition-api/.github/blob/main/CONTRIBUTING.md#commit-message-format)
- [x] All applicable pre-commit hooks have passed when running `pre-commit run --all-files`
- [x] All `tox` tests have succeeded

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
We are using the full tag version for reusable workflows and the pypi upload action.

Issue Number: N/A

## What is the new behavior?
<!-- Please describe the new behavior. -->
The team at coatl-dev has created tags with just the major version, so we will take advantage of them.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
