### PR TITLE
build(pre-commit): limit pylint to run against the src directory

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,4 +31,5 @@ repos:
         name: pylint
         entry: pylint
         language: system
+        files: ^src/
         types: [python]


### PR DESCRIPTION
when installing pylint in isolation, e.g. via pipx, it flags setup.py
with E0401 because it cannot find setuptools in that environment